### PR TITLE
fix: restrict api version regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ return {
           hover = true,
           schemas = {
             -- Add pre-configured schemas
+            -- Must not match any kubernetes manifests to avoid duplicate match
           },
         },
       },
@@ -130,6 +131,7 @@ return {
       trace = { server = "debug" },
       schemas = {
         -- Add pre-configured schemas
+        -- Must not match any kubernetes manifests to avoid duplicate match
       },
     },
   },

--- a/lua/nvim-k8s-lsp/init.lua
+++ b/lua/nvim-k8s-lsp/init.lua
@@ -38,14 +38,14 @@ local function table_contains(tbl, x)
 end
 
 local function extract_api_version(line)
-  local _, e = vim.regex([[^apiVersion: .*$]]):match_str(line)
+  local _, e = vim.regex([[^apiVersion: [a-zA-Z0-9-/\.]\+$]]):match_str(line)
   if e then
     return string.sub(line, 13, e)
   end
 end
 
 local function extract_kind(line)
-  local _, e = vim.regex([[^kind: .*$]]):match_str(line)
+  local _, e = vim.regex([[^kind: [a-zA-Z]\+$]]):match_str(line)
   if e then
     return string.sub(line, 7, e)
   end


### PR DESCRIPTION
The api version regex was too permisive and match go template syntax.
This trigger an error on the extraction.
